### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,9 @@
 
 name: Node.js Package
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]
@@ -21,6 +24,9 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/adz7180/HEXAAA.FINAL/security/code-scanning/2](https://github.com/adz7180/HEXAAA.FINAL/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for each job. For the `build` job, only read access to repository contents is needed. For the `publish-npm` job, write access to `packages` is required to publish the package, while other permissions should remain minimal.

The changes will be made in the `.github/workflows/npm-publish.yml` file:
1. Add a `permissions` block at the root level to set default permissions for all jobs.
2. Override the `permissions` block for the `publish-npm` job to grant `packages: write`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
